### PR TITLE
🐛 Split big rows into multiple

### DIFF
--- a/app/BusinessLogic/ReportManager.php
+++ b/app/BusinessLogic/ReportManager.php
@@ -43,10 +43,24 @@ class ReportManager implements ReportManagerContract
 
             $brandsData = $this->calculateAndAddAllBrandsData($brandsData, $category);
 
-            $this->addSection($category->name, $brandsData);
+            // issue with rendering big row using Dompdf library, 
+            // the workaround is to split the list of brands to
+            // multiple sections that each one can fit in page.
+            $this->splitBrandListIntoPages($brandsData, $category);
         }
 
         return $this->data;
+    }
+
+    protected function splitBrandListIntoPages($brandsData, $category)
+    {
+        if(count(array_chunk($brandsData, 25)) > 1) {
+            foreach(array_chunk($brandsData, 25) as $index => $chunk) {
+                $this->addSection($category->name . "-" . $index + 1, $chunk);
+            }
+        }else {
+            $this->addSection($category->name, $brandsData);
+        }
     }
 
     protected function addSection($sectionName, $data)


### PR DESCRIPTION
A known issue with Dompdf library, if the table row's height is more than the requested page, the cut content will not split to another page. Therefore, a workaround is to hard-code the split logic with max of 25 brands per page.